### PR TITLE
Update to newer MATLAB version

### DIFF
--- a/full/scripts/benchmark_results.m
+++ b/full/scripts/benchmark_results.m
@@ -53,7 +53,7 @@ scg_eval = eval_labels('SCG',database,gt_set,n_cands);
 % dimension the number of candidates. Set 'compute_masks = 1' in im2mcg
 % to see an example.
 
-% This function calls a 'matlabpool' to evaluate the masks in parallel,
+% This function calls a 'parpool' to evaluate the masks in parallel,
 % you should adapt the number of workers to your system, since it can take
 % a while, depending on the number of candidates
 % (hours if you have thousands of candidates). 

--- a/full/scripts/im2mcg_all.m
+++ b/full/scripts/im2mcg_all.m
@@ -44,7 +44,10 @@ end
 im_ids = database_ids(database,gt_set);
 
 % Sweep all images and process them in parallel
-matlabpool(4);
+num_workers = 4;
+if isempty(gcp('nocreate'))
+    parpool('local', num_workers)
+end
 num_images = length(im_ids);
 parfor im_id = 1:num_images 
     % File to store the candidates
@@ -62,7 +65,7 @@ parfor im_id = 1:num_images
         parsave(res_file,candidates);
     end
 end
-matlabpool close
+delete(gcp('nocreate'))
 end
 
 function parsave(res_file,candidates)

--- a/full/scripts/im2ucm_all.m
+++ b/full/scripts/im2ucm_all.m
@@ -44,7 +44,10 @@ end
 im_ids = database_ids(database,gt_set);
 
 % Sweep all images and process them in parallel
-matlabpool(4);
+num_workers = 4;
+if isempty(gcp('nocreate'))
+    parpool('local', num_workers)
+end
 parfor ii=1:length(im_ids)
     % Read image
     im = get_image(database,im_ids{ii});
@@ -59,8 +62,7 @@ parfor ii=1:length(im_ids)
         parsave(fullfile(res_dir,[im_ids{ii} '.mat']),ucm2)
     end
 end
-matlabpool close
-
+delete(gcp("nocreate"))
 end
 
 

--- a/full/src/benchmark/eval_and_save_masks.m
+++ b/full/src/benchmark/eval_and_save_masks.m
@@ -45,7 +45,10 @@ end
 im_ids = database_ids(database,gt_set);
 
 % Sweep all images in parallel
-matlabpool(4)
+num_workers = 4;
+if isempty(gcp('nocreate'))
+        parpool('local', num_workers)
+    end
 num_images = numel(im_ids);
 parfor ii=1:num_images
     curr_id = im_ids{ii};
@@ -99,7 +102,7 @@ parfor ii=1:num_images
     end
 end
 
-matlabpool close
+delete(gcp('nocreate'))
 
 end
 

--- a/full/src/ucms/spectralPb_fast.m
+++ b/full/src/ucms/spectralPb_fast.m
@@ -124,8 +124,8 @@ D = sparse(x, x, S, wx, wy);
 clear S x;
 
 
-opts.issym=1;
-opts.isreal = 1;
+% opts.issym=1; %(D - A) + (10^-10) * speye(size(D)) is a sparse double not a handle
+% opts.isreal = 1; %(D - A) + (10^-10) * speye(size(D)) is a sparse double not a handle
 opts.disp=0;
 [EV, EVal] = eigs((D - A) + (10^-10) * speye(size(D)), D, n_ev, 'sm', opts);
 clear D A opts;

--- a/pre-trained/scripts/im2mcg_all.m
+++ b/pre-trained/scripts/im2mcg_all.m
@@ -44,7 +44,9 @@ end
 im_ids = database_ids(database,gt_set);
 
 % Sweep all images and process them in parallel
-matlabpool open;
+if isempty(gcp('nocreate'))
+    parpool('local')
+end
 num_images = length(im_ids);
 parfor im_id = 1:num_images 
     % File to store the candidates
@@ -62,7 +64,7 @@ parfor im_id = 1:num_images
         parsave(res_file,candidates);
     end
 end
-matlabpool close
+delete(gcp("nocreate"))
 end
 
 function parsave(res_file,candidates)

--- a/pre-trained/scripts/im2ucm_all.m
+++ b/pre-trained/scripts/im2ucm_all.m
@@ -44,7 +44,9 @@ end
 im_ids = database_ids(database,gt_set);
 
 % Sweep all images and process them in parallel
-matlabpool open;
+if isempty(gcp('nocreate'))
+    parpool("local")
+end
 parfor ii=1:length(im_ids)
     % Read image
     im = get_image(database,im_ids{ii});
@@ -59,8 +61,7 @@ parfor ii=1:length(im_ids)
         parsave(fullfile(res_dir,[im_ids{ii} '.mat']),ucm2)
     end
 end
-matlabpool close
-
+delete(gcp("nocreate"))
 end
 
 

--- a/pre-trained/src/ucms/spectralPb_fast.m
+++ b/pre-trained/src/ucms/spectralPb_fast.m
@@ -123,9 +123,8 @@ S = full(sum(A, 1));
 D = sparse(x, x, S, wx, wy);
 clear S x;
 
-
-opts.issym=1;
-opts.isreal = 1;
+% opts.issym=1; %(D - A) + (10^-10) * speye(size(D)) is a sparse double not a handle
+% opts.isreal = 1; %(D - A) + (10^-10) * speye(size(D)) is a sparse double not a handle
 opts.disp=0;
 [EV, EVal] = eigs((D - A) + (10^-10) * speye(size(D)), D, n_ev, 'sm', opts);
 clear D A opts;


### PR DESCRIPTION
The biggest change so far was the removing of `matlabpool` since it was removed already in 2015a. Only in [full/scripts/im2mcg_all.m](https://github.com/jponttuset/mcg/compare/master...MaKaNu:changes_for_origin?expand=1#diff-6d193d696485d09d7827fec8cc40c43aa6fce1c145b76033f73d7f693de2c540) I added the support for older versions of MATLAB below 2014a. This was for the reason of to much boilerplate in the other functions. This function can be used later as a template if the inner part of the if statement is moved to a function or to an OOP approach.

Addinitonal there was a Warning in spectralPb_fast. I wrote a comment about the reason.